### PR TITLE
Extending options object in renderPartial

### DIFF
--- a/tasks/render.js
+++ b/tasks/render.js
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
         methods.renderPartial = function(filepath, data) {
 			var fpath = getFile(filepath, options.partialPaths);
 			if (fpath !== false) {
-				return render(fpath, _.defaults(options, {filename: fpath}, data));
+				return render(fpath, _.extend(options, {filename: fpath}, data));
 			}
 			return '';
 		};


### PR DESCRIPTION
In the `renderPartial` function I changed _.defaults to _.extend. This fixes a problem of not being able to have different options in multiple file rendering setup.
