### PR TITLE
Data as a function

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,6 +98,19 @@ module.exports = function(grunt) {
         files: {
           'tmp/render_partial': ['test/fixtures/render_partial'],
         }
+      },
+      data_function: {
+        options: {
+          data: function () {
+            return {
+              name: 'John',
+              surname: 'Doe'
+            };
+          }
+        },
+        files: {
+          'tmp/data_function': ['test/fixtures/data_function'],
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ Inside a template you may access Lo-Dash functions from `_`:
 
 
 #### options.data
-Type: `Object|Array`
+Type: `Object|Array|Function`
 Default value: `null`
 
 An object containing dynamic data to be passed to templates. 
+
+If data is a function, actual data passed to template is result of that function.
 
 You may also pass an array of JSON filepaths (any Grunt compatible globbing and template syntax is supported). `options.data` will be populated with files' contents.
 

--- a/tasks/render.js
+++ b/tasks/render.js
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
 			return '';
 		};
 
-        methods.renderPartial = function(filepath, data) {
+			methods.renderPartial = function(filepath, data) {
 			var fpath = getFile(filepath, options.partialPaths);
 			if (fpath !== false) {
 				return render(fpath, _.extend({}, options, {filename: fpath}, data || {}));
@@ -128,6 +128,8 @@ module.exports = function(grunt) {
 				});
 
 
+			} else if (_.isFunction(options.data)) {
+				options.data = options.data();
 			} else if (_.isString(options.data)) {
 				//DEPRECATED
 				//Kept for compatibility with older versions < 0.2.2

--- a/test/expected/data_function
+++ b/test/expected/data_function
@@ -1,0 +1,1 @@
+John Doe

--- a/test/fixtures/data_function
+++ b/test/fixtures/data_function
@@ -1,0 +1,1 @@
+<%= data.name %> <%= data.surname %>

--- a/test/render_test.js
+++ b/test/render_test.js
@@ -90,5 +90,14 @@ exports.render = {
     test.equal(actual, expected, 'partials got rendered with contextual data');
 
     test.done();
+  },
+  data_function: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/data_function').trim();
+    var expected = grunt.file.read('test/expected/data_function').trim();
+    test.equal(actual, expected, 'Template data is result of function call');
+
+    test.done();
   }
 };


### PR DESCRIPTION
With this change render task support builder function for data option. May be useful to make grunt runtime operations on templating scope, like this:

```
render: {
   index: {
        options: {
            data: function () {
                return { 
                    config: getConfig() 
                };
            }
        },
        files: {
            'index.html': 'index.ejs'
        }
    }
}
```
